### PR TITLE
Switch to static fns for entrypoint and general test improvements

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,5 @@
+# The wordpress:php7.2 image includes a pretty obtrusive entrypoint
+# FROM php:7.2-apache
 FROM wordpress:php7.2
 
 # Install apt dependencies
@@ -28,6 +30,3 @@ RUN chown -R www-data:www-data /var/www/ /usr/local/bin/
 # Install Composer
 COPY bin/install-composer.sh /tmp/
 RUN bash /tmp/install-composer.sh
-
-# Set workdir to plugin dir
-WORKDIR /var/www/html/wp-content/plugins/segment-cache-for-wp-engine

--- a/segment-cache-for-wp-engine.php
+++ b/segment-cache-for-wp-engine.php
@@ -3,7 +3,7 @@
  * Plugin Name: Segment Cache for WP Engine
  * Plugin URI: http://wordpress.org/plugins/segment-cache-on-wp-engine/
  * Description: Implement Segmented Caching on WP Engine.
- * Version: 1.0.1
+ * Version: 1.0.2
  * Author: Nate Gay
  * Author URI: https://nategay.me/
  * License: GPL3+
@@ -34,6 +34,6 @@ function get_segment_name() {
 }
 $segment_name = get_segment_name();
 
-new Send_Vary_Header( $segment_name );
-new Shortcode\Display_Segment( $segment_name );
-new Shortcode\Set_Segment();
+Send_Vary_Header::add_action( $segment_name );
+Shortcode\Display_Segment::add_shortcode( $segment_name );
+Shortcode\Set_Segment::add_shortcode();

--- a/src/class-send-vary-header.php
+++ b/src/class-send-vary-header.php
@@ -33,18 +33,6 @@ class Send_Vary_Header {
 	 */
 	public function __construct( $segment_name = null ) {
 		$this->segment_name = $segment_name;
-
-		// Send vary header in response when segment request header is present.
-		if ( $this->segment_name ) {
-			$this->add_action();
-		}
-	}
-
-	/**
-	 * Send headers via WordPress hook
-	 */
-	public function add_action() {
-		add_action( 'send_headers', array( $this, 'set_vary_header' ) );
 	}
 
 	/**
@@ -52,5 +40,20 @@ class Send_Vary_Header {
 	 */
 	public function set_vary_header() {
 		header( 'Vary: X-WPENGINE-SEGMENT' );
+	}
+
+	/**
+	 * Hook WordPress to send vary header in response only when segment_name is present.
+	 *
+	 * @param null|string $segment_name Name of header to segment on.
+	 * @return Send_Vary_Header
+	 */
+	public static function add_action( $segment_name = null ) {
+		// Send vary header in response when segment request header is present.
+		$send_vary_header = new Send_Vary_Header( $segment_name );
+		if ( $segment_name ) {
+			add_action( 'send_headers', array( $send_vary_header, 'set_vary_header' ) );
+		}
+		return $send_vary_header;
 	}
 }

--- a/src/shortcode/class-display-segment.php
+++ b/src/shortcode/class-display-segment.php
@@ -33,14 +33,6 @@ class Display_Segment {
 	 */
 	public function __construct( $segment_name = null ) {
 		$this->header_name = $segment_name;
-		$this->add_shortcode();
-	}
-
-	/**
-	 * Hook WordPress to add shortcode
-	 */
-	public function add_shortcode() {
-		add_shortcode( 'segment-cache-display', array( $this, 'display_segmented_content' ) );
 	}
 
 	/**
@@ -89,5 +81,15 @@ class Display_Segment {
 	public function escape_content( $atts = [], $content = '' ) {
 		$dangerously_set_html = isset( $atts['dangerously-set-html'] ) ? $atts['dangerously-set-html'] : false;
 		return $dangerously_set_html ? $content : esc_html( $content );
+	}
+
+	/**
+	 * Hook WordPress to add shortcode
+	 *
+	 * @param $segment_name null|string $segment_name Name of header to segment on.
+	 */
+	public static function add_shortcode( $segment_name = null ) {
+		$display_segment = new Display_Segment( $segment_name );
+		add_shortcode( 'segment-cache-display', array( $display_segment, 'display_segmented_content' ) );
 	}
 }

--- a/src/shortcode/class-set-segment.php
+++ b/src/shortcode/class-set-segment.php
@@ -63,20 +63,6 @@ class Set_Segment {
 	public $cookie_string = self::COOKIE_NAME . '=default';
 
 	/**
-	 * Constructor
-	 */
-	public function __construct() {
-		$this->add_shortcode();
-	}
-
-	/**
-	 * Hook WordPress to add shortcode
-	 */
-	public function add_shortcode() {
-		add_shortcode( 'segment-cache-set', array( $this, 'set_segment_cookie' ) );
-	}
-
-	/**
 	 * Set Segment
 	 *
 	 * This function acts as a factory and orchestrates all cookie setting actions after shortcode is invoked
@@ -145,5 +131,13 @@ class Set_Segment {
 		echo '<script type="text/javascript">';
 		echo 'document.cookie = "' . esc_attr( $this->cookie_string ) . '";';
 		echo '</script>';
+	}
+
+	/**
+	 * Hook WordPress to add shortcode
+	 */
+	public static function add_shortcode() {
+		$set_segment = new Set_Segment();
+		add_shortcode( 'segment-cache-set', array( $set_segment, 'set_segment_cookie' ) );
 	}
 }

--- a/test/phpunit.xml
+++ b/test/phpunit.xml
@@ -1,6 +1,6 @@
 <phpunit colors="true" bootstrap="bootstrap.php" convertNoticesToExceptions="true">
     <testsuites>
-        <testsuite name="segment-cache-for-wp-engine-unit-tests">
+        <testsuite name="unit-tests">
             <directory suffix="-test.php">unit</directory>
             <exclude>
                 <directory>../bin</directory>

--- a/test/unit/segment-cache-for-wp-engine-test.php
+++ b/test/unit/segment-cache-for-wp-engine-test.php
@@ -5,9 +5,7 @@
  * @package segment-cache-for-wp-engine
  */
 
-namespace SegmentCacheWPE\Shortcode;
-
-use function SegmentCacheWPE\get_segment_name;
+namespace SegmentCacheWPE;
 
 /**
  * Unit tests for SetSegment shortcode class
@@ -26,5 +24,25 @@ class SegmentCacheForWPEngine_Test extends \WP_UnitTestCase {
 		$_SERVER['HTTP_X_WPENGINE_SEGMENT'] = $expect;
 		$segment_name                       = get_segment_name();
 		$this->assertEquals( $expect, $segment_name );
+	}
+
+	/**
+	 * Verify shortcodes are added
+	 */
+	public function test_adding_shortcodes() {
+		$segment_cache_display_shortcode = shortcode_exists( 'segment-cache-display' );
+		$segment_cache_set_shortcode     = shortcode_exists( 'segment-cache-set' );
+		$this->assertTrue( $segment_cache_display_shortcode );
+		$this->assertTrue( $segment_cache_set_shortcode );
+	}
+
+	/**
+	 * Since $segment_name is not set when bootstrap.php includes segment-cache-for-wp-engine.php,
+	 * verify action is not added
+	 */
+	public function test_adding_action() {
+		global $wp_filter;
+		$action_exists = array_key_exists( 'send_headers', $wp_filter );
+		$this->assertFalse( $action_exists );
 	}
 }

--- a/test/unit/src/class-send-vary-header-test.php
+++ b/test/unit/src/class-send-vary-header-test.php
@@ -18,12 +18,12 @@ class SendVaryHeader_Test extends \WP_UnitTestCase {
 	 */
 	public function test_constructor_logic() {
 		// Test without segment_name.
-		$send_vary_header = new Send_Vary_Header();
-		$hook_priority    = has_action( 'send_headers', array( $send_vary_header, 'add_action' ) );
+		$send_vary_header = Send_Vary_Header::add_action();
+		$hook_priority    = has_action( 'send_headers', array( $send_vary_header, 'set_vary_header' ) );
 		$this->assertFalse( $hook_priority );
 
 		// Test with segment_name.
-		$send_vary_header = new Send_Vary_Header( 'test' );
+		$send_vary_header = Send_Vary_Header::add_action( 'test' );
 		$hook_priority    = has_action( 'send_headers', array( $send_vary_header, 'set_vary_header' ) );
 		$this->assertInternalType( 'int', $hook_priority );
 	}
@@ -34,7 +34,7 @@ class SendVaryHeader_Test extends \WP_UnitTestCase {
 	 * @runInSeparateProcess
 	 */
 	public function test_set_vary_header() {
-		new Send_Vary_Header( 'hello' );
+		Send_Vary_Header::add_action( 'hello' );
 		do_action( 'send_headers' );
 		$expect         = 'Vary: X-WPENGINE-SEGMENT';
 		$headers_string = join( '', xdebug_get_headers() );

--- a/test/unit/src/shortcode/class-display-segment-test.php
+++ b/test/unit/src/shortcode/class-display-segment-test.php
@@ -12,10 +12,21 @@ namespace SegmentCacheWPE\Shortcode;
  */
 class DisplaySegment_Test extends \WP_UnitTestCase {
 	/**
-	 * Ensure shortcode is added when class is initialized
+	 * Shortcode is automatically added when bootstrap.php loads segment-cache-for-wp-engine.php.
+	 * Let's remove it so we can test some things.
 	 */
-	public function test_shortcode_added_on_init() {
-		new Display_Segment();
+	public function setUp() {
+		remove_shortcode( 'segment-cache-display' );
+	}
+
+	/**
+	 * Ensure shortcode is added
+	 */
+	public function test_adding_shortcode() {
+		$shortcode_exists = shortcode_exists( 'segment-cache-display' );
+		$this->assertFalse( $shortcode_exists );
+
+		Display_Segment::add_shortcode();
 		$shortcode_exists = shortcode_exists( 'segment-cache-display' );
 		$this->assertTrue( $shortcode_exists );
 	}

--- a/test/unit/src/shortcode/class-set-segment-test.php
+++ b/test/unit/src/shortcode/class-set-segment-test.php
@@ -12,10 +12,21 @@ namespace SegmentCacheWPE\Shortcode;
  */
 class SetSegment_Test extends \WP_UnitTestCase {
 	/**
-	 * Ensure shortcode is added when class is initialized
+	 * Shortcode is automatically added when bootstrap.php loads segment-cache-for-wp-engine.php.
+	 * Let's remove it so we can test some things.
 	 */
-	public function test_shortcode_added_on_init() {
-		new Set_Segment();
+	public function setUp() {
+		remove_shortcode( 'segment-cache-set' );
+	}
+
+	/**
+	 * Ensure shortcode is added
+	 */
+	public function test_adding_shortcode() {
+		$shortcode_exists = shortcode_exists( 'segment-cache-set' );
+		$this->assertFalse( $shortcode_exists );
+
+		Set_Segment::add_shortcode();
 		$shortcode_exists = shortcode_exists( 'segment-cache-set' );
 		$this->assertTrue( $shortcode_exists );
 	}


### PR DESCRIPTION
Swapped out constructor side effects for static functions as suggested by code climate. Found out that wordpress docker entrypoint automatically installs wp in workdir... so changed workdir back to default and added cd to all docker commands in Makefile. Noticed some tests that should have been failing were passing because of side effect of bootstrap.php. Improved test validity.