### PR TITLE
Reintroduce before_deploy logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ stages:
   - name: after_script
     if: branch = master
   - name: before_deploy
-    if: branch = master AND env(BUILD_VERSION) IS NOT present
+    if: branch = master
   - name: deploy
     if: branch = master
 
@@ -44,10 +44,13 @@ after_script:
   - ./cc-test-reporter after-build -t clover --exit-code $TRAVIS_TEST_RESULT
 
 before_deploy:
-  - export BUILD_VERSION="$(make get_version)"
-  - git config --local user.name "nateinaction";
-  - git config --local user.email "email@nategay.me";
-  - git tag "v${BUILD_VERSION}";
+  - >
+     if ! [ "${BUILD_VERSION}" ]; then
+       export BUILD_VERSION=$(make get_version);
+       git config --local user.name "nateinaction";
+       git config --local user.email "email@nategay.me";
+       git tag "v${BUILD_VERSION}";
+     fi
 
 deploy:
   - provider: releases

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ COMPOSER_DIR := -d "/workspace/"
 BUILD_DIR := ./build
 
 # Commands
-all: lint verify_new_version composer_install test build
+all: verify_new_version lint composer_install test build
 
 lint:
 	$(DOCKER_RUN) $(PHPCS_DOCKER_IMAGE) .

--- a/segment-cache-for-wp-engine.php
+++ b/segment-cache-for-wp-engine.php
@@ -3,7 +3,7 @@
  * Plugin Name: Segment Cache for WP Engine
  * Plugin URI: http://wordpress.org/plugins/segment-cache-on-wp-engine/
  * Description: Implement Segmented Caching on WP Engine.
- * Version: 1.0.9
+ * Version: 1.0.10
  * Author: Nate Gay
  * Author URI: https://nategay.me/
  * License: GPL3+


### PR DESCRIPTION
In #15 I removed logic around the before_deploy step in the travis build. This caused a build failure.